### PR TITLE
use getk in mget

### DIFF
--- a/lib/memcache_client.ex
+++ b/lib/memcache_client.ex
@@ -78,7 +78,7 @@ defmodule Memcache.Client do
   """
   @spec mget(Enumerable.t) :: Stream.t
   def mget(keys) do
-    requests = Enum.map(keys, &(%Request{opcode: :get, key: &1}))
+    requests = Enum.map(keys, &(%Request{opcode: :getk, key: &1}))
     multi_request(requests)
   end
 

--- a/lib/memcache_client.ex
+++ b/lib/memcache_client.ex
@@ -221,6 +221,9 @@ defmodule Memcache.Client do
                 {[response], acc}
               end
             {:response, {:error, reason}} ->
+              if reason == :timeout do
+                :ok = Worker.close(worker)
+              end
               {[%Response{status: reason, value: "#{reason}"}], {worker, :halt}}
           end
         {_worker, :halt} = acc ->


### PR DESCRIPTION
there are no cache miss when use `getq`, use `getk` in mget let user can conveniently deal with cache miss
