### PR TITLE
Features/port as integer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ notifications:
     - teemu.harju@gmail.com
 
 otp_release:
-  - 17.0
+  - 19.0
 before_install:
   - echo "yes" | sudo add-apt-repository ppa:travis-ci/memcached-sasl
   - sudo apt-get update

--- a/lib/memcache_client.ex
+++ b/lib/memcache_client.ex
@@ -238,11 +238,11 @@ defmodule Memcache.Client do
   end
 
   defp do_multi_request([request], worker) do
-    Worker.cast(worker, self, request, request.opcode)
+    Worker.cast(worker, self(), request, request.opcode)
   end
 
   defp do_multi_request([request | requests], worker) do
-    Worker.cast(worker, self, request, Opcode.to_quiet(request.opcode))
+    Worker.cast(worker, self(), request, Opcode.to_quiet(request.opcode))
     do_multi_request(requests, worker)
   end
 

--- a/lib/memcache_client/config_parser.ex
+++ b/lib/memcache_client/config_parser.ex
@@ -1,0 +1,20 @@
+defmodule Memcache.Client.ConfigParser do
+  def to_binary(arg) do
+    case arg do
+      value when is_binary(value) -> String.to_char_list(value)
+      value -> value
+    end
+  end
+
+  def to_integer(arg) do
+    case arg do
+      nil -> nil
+      value when is_integer(value) -> value
+      value ->
+        case Integer.parse(value) do
+          {int, _} -> int
+          :error -> value
+        end
+    end
+  end
+end

--- a/lib/memcache_client/worker.ex
+++ b/lib/memcache_client/worker.ex
@@ -5,11 +5,12 @@ defmodule Memcache.Client.Worker do
   alias Memcache.Client.Serialization.Opcode
   alias Memcache.Client.Serialization.Header
   alias Memcache.Client.Serialization
+  alias Memcache.Client.ConfigParser
 
   @backoff_time 1000
 
   defmodule State do
-    defstruct host: "127.0.0.1",
+    defstruct host: '127.0.0.1',
       port: 11211,
       opts: [],
       timeout: 5000,
@@ -32,16 +33,11 @@ defmodule Memcache.Client.Worker do
   end
 
   def init(args) do
-    host = case Keyword.get(args, :host) do
-      host_arg when is_binary(host_arg) -> String.to_char_list(host_arg)
-      host_arg -> host_arg
-    end
-
     state = %State{
-      host: host,
-      port: Keyword.get(args, :port),
+      host: args |> Keyword.get(:host) |> ConfigParser.to_binary,
+      port: args |> Keyword.get(:port) |> ConfigParser.to_integer,
       opts: Keyword.get(args, :opts),
-      timeout: Keyword.get(args, :timeout),
+      timeout: args |> Keyword.get(:timeout) |> ConfigParser.to_integer,
       auth_method: Keyword.get(args, :auth_method),
       username: Keyword.get(args, :username),
       password: Keyword.get(args, :password)

--- a/mix.exs
+++ b/mix.exs
@@ -4,12 +4,12 @@ defmodule Memcache.Client.Mixfile do
   def project do
     [app: :memcache_client,
      version: "1.1.1",
-     elixir: "~> 1.0",
-     description: description,
-     package: package,
+     elixir: "~> 1.4",
+     description: description(),
+     package: package(),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   def application do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Memcache.Client.Mixfile do
   def project do
     [app: :memcache_client,
      version: "1.1.1",
-     elixir: "~> 1.4",
+     elixir: "~> 1.0",
      description: description(),
      package: package(),
      build_embedded: Mix.env == :prod,

--- a/test/worker_test.exs
+++ b/test/worker_test.exs
@@ -1,0 +1,19 @@
+defmodule Memcache.Client.WorkerTest do
+  use ExUnit.Case
+  alias Memcache.Client.Worker
+
+  test "port settins as integer" do
+    {:connect, :init, state} = Worker.init([host: "127.0.0.1", port: "11211", timeout: "5000"])
+    assert %Memcache.Client.Worker.State{
+      host: '127.0.0.1',
+      port: 11211,
+      auth_method: nil,
+      from: nil,
+      opts: nil,
+      password: nil,
+      socket: nil,
+      timeout: 5000,
+      username: nil
+    } == state
+  end
+end


### PR DESCRIPTION
Hi, Teemu!
Our team using your library in project, but we have a problem with configuring. Unfortunately, if you use release tools (like distillery), ENV variables will be only as strings. But erlang :tcp need only integer value.
p/s/ also I can update deps in the next merge request.