### PR TITLE
Update for Elixir 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ notifications:
     - teemu.harju@gmail.com
 
 otp_release:
-  - 17.0
+  - 19.0
 before_install:
   - echo "yes" | sudo add-apt-repository ppa:travis-ci/memcached-sasl
   - sudo apt-get update

--- a/lib/memcache_client.ex
+++ b/lib/memcache_client.ex
@@ -210,11 +210,11 @@ defmodule Memcache.Client do
                 end
               end
 
-              unless Opcode.quiet?(header.opcode) do
+              if Opcode.quiet?(header.opcode) do
                 # we'll halt since there won't be anymore results
-                {[%Response{status: header.status, cas: header.cas, key: key, value: value, extras: extras}], {worker, :halt}}
-              else
                 {[%Response{status: header.status, cas: header.cas, key: key, value: value, extras: extras}], acc}
+              else
+                {[%Response{status: header.status, cas: header.cas, key: key, value: value, extras: extras}], {worker, :halt}}
               end
 
             {:response, {:error, reason}} ->

--- a/lib/memcache_client.ex
+++ b/lib/memcache_client.ex
@@ -238,11 +238,11 @@ defmodule Memcache.Client do
   end
 
   defp do_multi_request([request], worker) do
-    Worker.cast(worker, self, request, request.opcode)
+    Worker.cast(worker, self(), request, request.opcode)
   end
 
   defp do_multi_request([request | requests], worker) do
-    Worker.cast(worker, self, request, Opcode.to_quiet(request.opcode))
+    Worker.cast(worker, self(), request, Opcode.to_quiet(request.opcode))
     do_multi_request(requests, worker)
   end
 

--- a/lib/memcache_client/transcoder.ex
+++ b/lib/memcache_client/transcoder.ex
@@ -1,9 +1,7 @@
 defmodule Memcache.Client.Transcoder do
 
-  use Behaviour
-  
-  defcallback encode_value(value :: any) :: {binary, binary}
-  defcallback decode_value(value :: binary, data_type :: binary) :: any
+  @callback encode_value(value :: any) :: {binary, binary}
+  @callback decode_value(value :: binary, data_type :: binary) :: any
 
   def encode_value(value) do
     transcoder = Application.get_env(:memcache_client, :transcoder, Memcache.Client.Transcoder.Raw)
@@ -14,7 +12,7 @@ defmodule Memcache.Client.Transcoder do
     transcoder = Application.get_env(:memcache_client, :transcoder, Memcache.Client.Transcoder.Raw)
     transcoder.decode_value(value, data_type)
   end
-  
+
 end
 
 defmodule Memcache.Client.Transcoder.Erlang do

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule Memcache.Client.Mixfile do
     [
       {:earmark, "~> 0.2.0", only: :dev},
       {:ex_doc, "~> 0.11.4", only: :dev},
-      {:poison, "~> 2.2.0"},
+      {:poison, "~> 3.1"},
       {:poolboy, "~> 1.5.1"},
       {:connection, "~> 1.0.2"}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -5,11 +5,11 @@ defmodule Memcache.Client.Mixfile do
     [app: :memcache_client,
      version: "1.1.1",
      elixir: "~> 1.0",
-     description: description,
-     package: package,
+     description: description(),
+     package: package(),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   def application do
@@ -19,11 +19,11 @@ defmodule Memcache.Client.Mixfile do
 
   defp deps do
     [
-      {:earmark, "~> 0.2.0", only: :dev},
-      {:ex_doc, "~> 0.11.4", only: :dev},
+      {:earmark, "~> 1.2.0", only: :dev},
+      {:ex_doc, "~> 0.14", only: :dev},
       {:poison, "~> 3.1"},
       {:poolboy, "~> 1.5.1"},
-      {:connection, "~> 1.0.2"}
+      {:connection, "~> 1.0.4"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
-%{"connection": {:hex, :connection, "1.0.2", "f4a06dd3ecae4141aa66f94ce92ea4c4b8753069472814932f1cadbc3078ab80", [:mix], []},
-  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.11.4", "a064bdb720594c3745b94709b17ffb834fd858b4e0c1f48f37c0d92700759e02", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
+%{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
+  "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.15.1", "d5f9d588fd802152516fccfdb96d6073753f77314fcfee892b15b6724ca0d596", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"connection": {:hex, :connection, "1.0.2", "f4a06dd3ecae4141aa66f94ce92ea4c4b8753069472814932f1cadbc3078ab80", [:mix], []},
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.11.4", "a064bdb720594c3745b94709b17ffb834fd858b4e0c1f48f37c0d92700759e02", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
-  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []}}


### PR DESCRIPTION
Hi, @tsharju .
Thanks for this useful library, and I updated some code for latest version of Elixir (and Erlang/OTP :) ).

*  At `transcoder.ex`, Now `Behaviour` module  is duplicated, so I replaced `@callback` annotations for transcoder interface.
See this : https://hexdocs.pm/elixir/Behaviour.html

* Updated travis otp version, 17 to 19.

* At `mix.exs`, Updated versions of mix package. 

* Added () for missing parens warnings of Elixir 1.4, (e.g. packages -> package(), deps -> deps(), self -> self())